### PR TITLE
Add support to netrc

### DIFF
--- a/src/tesk_core/filer.py
+++ b/src/tesk_core/filer.py
@@ -38,7 +38,11 @@ class Transput:
         self.url_path = parsed_url.path
         self.netrc_file = None
         try:
-            self.netrc_file = netrc.netrc(os.path.join(os.environ['HOME'], '.netrc'))
+            netrc_path = os.path.join(os.environ['HOME'], '.netrc')
+        except KeyError as kerror:
+            netrc_path = '/.netrc'
+        try:
+            self.netrc_file = netrc.netrc(netrc_path)
         except IOError as fnfe:
             logging.error(fnfe)
         except netrc.NetrcParseError as err:

--- a/src/tesk_core/filer.py
+++ b/src/tesk_core/filer.py
@@ -10,6 +10,7 @@ import os
 import enum
 import distutils.dir_util
 import logging
+import netrc
 import requests
 from tesk_core.exception import UnknownProtocol, FileProtocolDisabled
 import shutil
@@ -35,6 +36,14 @@ class Transput:
         parsed_url = urlparse(url)
         self.netloc = parsed_url.netloc
         self.url_path = parsed_url.path
+        self.netrc_file = None
+        try:
+            self.netrc_file = netrc.netrc(os.path.join(os.environ['HOME'], '.netrc'))
+        except IOError as fnfe:
+            logging.error(fnfe)
+        except netrc.NetrcParseError as err:
+            logging.error('netrc.NetrcParseError')
+            logging.error(err)
 
     def upload(self):
         logging.debug('%s uploading %s %s', self.__class__.__name__, self.ftype, self.url)
@@ -187,7 +196,7 @@ class FTPTransput(Transput):
     def __enter__(self):
         if self.connection_owner:
             self.ftp_connection.connect(self.netloc)
-            ftp_login(self.ftp_connection)
+            ftp_login(self.ftp_connection, self.netloc, self.netrc_file)
         return self
 
     def upload_dir(self):
@@ -275,10 +284,16 @@ class FTPTransput(Transput):
             self.ftp_connection.close()
 
 
-def ftp_login(ftp_connection):
-    if 'TESK_FTP_USERNAME' in os.environ and 'TESK_FTP_PASSWORD' in os.environ:
+def ftp_login(ftp_connection, netloc, netrc_file):
+    if netrc_file is not None:
+        creds = netrc_file.authenticators(netloc)
+        if creds:
+            user, _, password = creds
+    elif 'TESK_FTP_USERNAME' in os.environ and 'TESK_FTP_PASSWORD' in os.environ:
         user = os.environ['TESK_FTP_USERNAME']
         password = os.environ['TESK_FTP_PASSWORD']
+
+    if user:
         try:
             ftp_connection.login(user, password)
         except ftplib.error_perm:

--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -1,4 +1,5 @@
 import json
+import os
 from tesk_core import path
 from tesk_core.path import fileEnabled
 
@@ -69,6 +70,31 @@ class Filer:
         self.getVolumeMounts().extend(pvc.volume_mounts)
         self.getVolumes().append({ "name"                  : "task-volume",
                                    "persistentVolumeClaim" : {"claimName": pvc.name}})
+
+
+    def add_netrc_mount(self, netrc_name='netrc'):
+        '''
+            Mounts the secret netrc into $HOME/.netrc. Neither the secret name nor the folder
+                can be changed.
+        '''
+
+        self.getVolumeMounts().append({"name"      : 'netrc',
+                                       "mountPath" : os.path.join(os.environ['HOME'], '.netrc'),
+                                       "subPath" : ".netrc"
+                                      })
+        self.getVolumes().append({"name"   : "netrc",
+                                  "secret" : {
+                                      "secretName" : netrc_name,
+                                      "defaultMode" :  420,
+                                      "items" : [
+                                          {
+                                              "key": "netrc",
+                                              "path": ".netrc"
+                                          }
+                                      ]
+                                  }
+                                 })
+
 
     def get_spec(self, mode, debug=False):
         self.spec['spec']['template']['spec']['containers'][0]['args'] = [

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -110,6 +110,9 @@ def init_pvc(data, filer):
     global created_pvc
     created_pvc = pvc
 
+    if os.environ.get('NETRC_SECRET_NAME') is not None:
+        filer.add_netrc_mount(os.environ.get('NETRC_SECRET_NAME'))
+
     filerjob = Job(
         filer.get_spec('inputs', args.debug),
         task_name + '-inputs-filer',


### PR DESCRIPTION
If the environment variable 'NETRC_SECRET_NAME' is present, and the content of the secret is a valid netrc file, it will be used for authentication. Otherwise the previous method of FTP_* variable will be used for backwards compatibility reasons.