### PR TITLE
WIP Fix already created PVC error

### DIFF
--- a/src/tesk_core/pvc.py
+++ b/src/tesk_core/pvc.py
@@ -1,4 +1,5 @@
 from kubernetes import client, config
+from kubernetes.client.rest import ApiException
 from tesk_core.Util import pprint
 import logging
 
@@ -34,7 +35,12 @@ class PVC():
         logging.debug('Creating PVC...')
         logging.debug(pprint(self.spec))
         
-        return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
+        try:
+            return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
+        except ApiException as apiex:
+            logging.error('ApiException', apiex)
+            # If the PVC already exists, search for it and return it.
+            return self.cv1.read_namespaced_persistent_volume_claim(self.name, self.namespace)
 
     def delete(self):
         cv1 = client.CoreV1Api()

--- a/src/tesk_core/pvc.py
+++ b/src/tesk_core/pvc.py
@@ -1,7 +1,7 @@
+import logging
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 from tesk_core.Util import pprint
-import logging
 
 
 class PVC():
@@ -29,16 +29,16 @@ class PVC():
         subpath = 'dir' + str(self.subpath_idx)
         self.subpath_idx += 1
         return subpath
-    
+
     def create(self):
-        
+
         logging.debug('Creating PVC...')
         logging.debug(pprint(self.spec))
-        
+
         try:
             return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
         except ApiException as apiex:
-            logging.error('ApiException', apiex)
+            logging.error('ApiException: %s' % apiex.reason)
             # If the PVC already exists, search for it and return it.
             return self.cv1.read_namespaced_persistent_volume_claim(self.name, self.namespace)
 


### PR DESCRIPTION
Simple fix to avoid the error when the PVC was already created. It caches the exception and tries to search for the PVC.