### PR TITLE
fix(ftp): stopped ftp errors silencing

### DIFF
--- a/src/tesk_core/filer.py
+++ b/src/tesk_core/filer.py
@@ -504,8 +504,13 @@ def main():
 
     data = json.loads(args.data)
 
-    for afile in data[args.transputtype]:                                                                                                                                                                                                            logging.debug('Processing file: %s', afile['path'])                                                                                                                                                                                          if process_file(args.transputtype, afile) != 0:                                                                                                                                                                                                  logging.error('Unable to process file, aborting')                                                                                                                                                                                            return 1                                                                                                                                                                                                                                 logging.debug('Processed file: %s', afile['path'])
-    
+    for afile in data[args.transputtype]:
+        logging.debug('Processing file: %s', afile['path'])
+        if process_file(args.transputtype, afile) != 0:
+            logging.error('Unable to process file, aborting')
+            return 1
+        logging.debug('Processed file: %s', afile['path'])
+
     return 0
 
 

--- a/src/tesk_core/filer.py
+++ b/src/tesk_core/filer.py
@@ -504,11 +504,8 @@ def main():
 
     data = json.loads(args.data)
 
-    for afile in data[args.transputtype]:
-        logging.debug('Processing file: %s', afile['path'])
-        process_file(args.transputtype, afile)
-        logging.debug('Processed file: %s', afile['path'])
-
+    for afile in data[args.transputtype]:                                                                                                                                                                                                            logging.debug('Processing file: %s', afile['path'])                                                                                                                                                                                          if process_file(args.transputtype, afile) != 0:                                                                                                                                                                                                  logging.error('Unable to process file, aborting')                                                                                                                                                                                            return 1                                                                                                                                                                                                                                 logging.debug('Processed file: %s', afile['path'])
+    
     return 0
 
 


### PR DESCRIPTION
FTP errors were not propagated, resulting in jobs completing while FTP errors were present
Fixes #20 