### PR TITLE
feat(api): variable jobs backoff limits

### DIFF
--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -67,7 +67,7 @@ class Filer:
 
     def set_backoffLimit(self, limit):
         """Set a number of retries of a job execution (default value is 6). Use the environment variable
-        TESK_API_FILER_ENVIRONMENT_BACKOFF_LIMIT to explicitly set this value.
+        TESK_API_TASKMASTER_ENVIRONMENT_FILER_BACKOFF_LIMIT to explicitly set this value.
 
         Args:
             limit: The number of retries before considering a Job as failed.

--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -65,6 +65,15 @@ class Filer:
         env.append({"name": "TESK_FTP_USERNAME", "value": user})
         env.append({"name": "TESK_FTP_PASSWORD", "value": pw})
 
+    def set_backoffLimit(self, limit):
+        """Set a number of retries of a job execution (default value is 6). Use the environment variable
+        TESK_API_FILER_ENVIRONMENT_BACKOFF_LIMIT to explicitly set this value.
+
+        Args:
+            limit: The number of retries before considering a Job as failed.
+        """
+        self.spec['spec'].update({"backoffLimit": limit})
+
     def add_volume_mount(self, pvc):
         self.getVolumeMounts().extend(pvc.volume_mounts)
         self.getVolumes().append({ "name"                  : "task-volume",

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -21,6 +21,9 @@ def run_executor(executor, namespace, pvc=None):
     jobname = executor['metadata']['name']
     spec = executor['spec']['template']['spec']
 
+    if os.environ.get('TESK_API_EXECUTOR_ENVIRONMENT_BACKOFF_LIMIT') is not None:
+        executor['spec'].update({'backoffLimit': os.environ['TESK_API_EXECUTOR_ENVIRONMENT_BACKOFF_LIMIT']})
+
     if pvc is not None:
         mounts = spec['containers'][0].setdefault('volumeMounts', [])
         mounts.extend(pvc.volume_mounts)
@@ -136,6 +139,9 @@ def run_task(data, filer_name, filer_version):
             filer.set_ftp(
                 os.environ['TESK_FTP_USERNAME'],
                 os.environ['TESK_FTP_PASSWORD'])
+        
+        if os.environ.get('TESK_API_FILER_ENVIRONMENT_BACKOFF_LIMIT') is not None:
+            filer.set_backoffLimit(os.environ['TESK_API_FILER_ENVIRONMENT_BACKOFF_LIMIT'])
 
         pvc = init_pvc(data, filer)
 

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -21,8 +21,8 @@ def run_executor(executor, namespace, pvc=None):
     jobname = executor['metadata']['name']
     spec = executor['spec']['template']['spec']
 
-    if os.environ.get('TESK_API_EXECUTOR_ENVIRONMENT_BACKOFF_LIMIT') is not None:
-        executor['spec'].update({'backoffLimit': os.environ['TESK_API_EXECUTOR_ENVIRONMENT_BACKOFF_LIMIT']})
+    if os.environ.get('TESK_API_TASKMASTER_ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT') is not None:
+        executor['spec'].update({'backoffLimit': os.environ['TESK_API_TASKMASTER_ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT']})
 
     if pvc is not None:
         mounts = spec['containers'][0].setdefault('volumeMounts', [])
@@ -140,8 +140,8 @@ def run_task(data, filer_name, filer_version):
                 os.environ['TESK_FTP_USERNAME'],
                 os.environ['TESK_FTP_PASSWORD'])
         
-        if os.environ.get('TESK_API_FILER_ENVIRONMENT_BACKOFF_LIMIT') is not None:
-            filer.set_backoffLimit(os.environ['TESK_API_FILER_ENVIRONMENT_BACKOFF_LIMIT'])
+        if os.environ.get('TESK_API_TASKMASTER_ENVIRONMENT_FILER_BACKOFF_LIMIT') is not None:
+            filer.set_backoffLimit(os.environ['TESK_API_TASKMASTER_ENVIRONMENT_FILER_BACKOFF_LIMIT'])
 
         pvc = init_pvc(data, filer)
 

--- a/tests/FilerClassTest.py
+++ b/tests/FilerClassTest.py
@@ -21,7 +21,8 @@ class FilerClassTest_env(unittest.TestCase):
     def test_env_vars(self):
         
         f = Filer('name', {'a': 1})
-        
+        f.set_backoffLimit(10)
+
         pprint(f.spec)
         
         self.assertEquals(f.getEnv(), [
@@ -30,7 +31,7 @@ class FilerClassTest_env(unittest.TestCase):
            ,{ 'name': 'HOST_BASE_PATH'       , 'value': '/home/tfga/workspace/cwl-tes'  }
            ,{ 'name': 'CONTAINER_BASE_PATH'  , 'value': '/transfer'                     }
         ])
-
+        self.assertEquals(f.spec['spec']['backoffLimit'], 10)
     
     def test_mounts(self):
         '''


### PR DESCRIPTION
The number of retries before considering a K8s job as failed (see [this](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy)) can now be explicitly set through the following 2 environment variables for executor and filer jobs, respectively:
* `TESK_API_TASKMASTER_ENVIRONMENT_EXECUTOR_BACKOFF_LIMIT`
* `TESK_API_TASKMASTER_ENVIRONMENT_FILER_BACKOFF_LIMIT`