### PR TITLE
Tasks queuing forever when ImagePullError

### DIFF
--- a/src/tesk_core/job.py
+++ b/src/tesk_core/job.py
@@ -17,7 +17,7 @@ class Job:
         self.body = body
         self.body['metadata']['name'] = self.name
 
-    def run_to_completion(self, poll_interval, check_cancelled, pod_timeout=240):
+    def run_to_completion(self, poll_interval, check_cancelled, pod_timeout):
 
         logging.debug("Creating job '{}'...".format(self.name))
         logging.debug(pprint(self.body))

--- a/src/tesk_core/job.py
+++ b/src/tesk_core/job.py
@@ -1,37 +1,39 @@
 import logging
 import time
+from datetime import datetime, timezone
 from kubernetes import client, config
 from tesk_core.Util import pprint
 
 
+logging.basicConfig(format='%(message)s', level=logging.INFO)
 class Job:
     def __init__(self, body, name='task-job', namespace='default'):
         self.name = name
         self.namespace = namespace
         self.status = 'Initialized'
         self.bv1 = client.BatchV1Api()
+        self.cv1 = client.CoreV1Api()
+        self.timeout = 240
         self.body = body
         self.body['metadata']['name'] = self.name
 
-    def run_to_completion(self, poll_interval, check_cancelled):
-        
+    def run_to_completion(self, poll_interval, check_cancelled, pod_timeout=240):
+
         logging.debug("Creating job '{}'...".format(self.name))
         logging.debug(pprint(self.body))
-        
+        self.timeout = pod_timeout
         self.bv1.create_namespaced_job(self.namespace, self.body)
-        status = self.get_status()
+        is_all_pods_running = False
+        status, is_all_pods_running = self.get_status(is_all_pods_running)
         while status == 'Running':
             if check_cancelled():
                 self.delete()
                 return 'Cancelled'
-
             time.sleep(poll_interval)
-
-            status = self.get_status()
-
+            status, is_all_pods_running = self.get_status(is_all_pods_running)
         return status
 
-    def get_status(self):
+    def get_status(self, is_all_pods_runnning):
         job = self.bv1.read_namespaced_job(self.name, self.namespace)
         try:
             if job.status.conditions[0].type == 'Complete' and job.status.conditions[0].status:
@@ -42,9 +44,25 @@ class Job:
                 self.status = 'Error'
         except TypeError:  # The condition is not initialized, so it is not complete yet, wait for it
             self.status = 'Running'
+            job_duration = 0
+            if job.status.active and job.status.start_time:
+                job_duration = (datetime.now(timezone.utc) - job.status.start_time).total_seconds()
+            if job_duration > self.timeout and not is_all_pods_runnning:
+                pods = (self.cv1.list_namespaced_pod(self.namespace
+                                                    , label_selector='job-name={}'.format(self.name))).items
+                is_all_pods_runnning = True
+                for pod in pods:
+                    if pod.status.phase == "Pending":
+                        is_all_pods_runnning = False
+                        delta = (datetime.now(timezone.utc) - pod.status.start_time).total_seconds()
+                        if delta > self.timeout and \
+                                pod.status.container_statuses[0].state.waiting.reason == "ImagePullBackOff":
+                            logging.info(pod.status.container_statuses[0].state.waiting)
+                            return 'Error', is_all_pods_runnning
 
-        return self.status
+        return self.status, is_all_pods_runnning
 
     def delete(self):
+        logging.info("Removing failed jobs")
         self.bv1.delete_namespaced_job(
-            self.name, self.namespace, client.V1DeleteOptions())
+            self.name, self.namespace, body=client.V1DeleteOptions(propagation_policy="Background"))

--- a/src/tesk_core/pvc.py
+++ b/src/tesk_core/pvc.py
@@ -39,4 +39,4 @@ class PVC():
     def delete(self):
         cv1 = client.CoreV1Api()
         cv1.delete_namespaced_persistent_volume_claim(
-            self.name, self.namespace, client.V1DeleteOptions())
+            self.name, self.namespace, body=client.V1DeleteOptions())


### PR DESCRIPTION
**Problem:** The pod was going in a pending stage when the task was created with an invalid/wrong image. 

**Proposed solution:** When the Executor job is created, after a specified time limit, the status of all the scheduled pods will be checked. If the pods are in the running state, the get status method assumes the Executor job is running as expected and stops polling pods to find the status. However, if a pod is stuck in a pending stage after the time limit, the reason for the error is logged onto the stdout and  "Error" status is raised against the executor job. Finally, the failed Job and the pods are deleted from the cluster.

**Sample TESK-API output for the failed Job** 
```{
  "tasks" : [ {
    "id" : "task-5bf2f120",
    "state" : "SYSTEM_ERROR",
    "description" : "Demonstrates capturing stdout to file (and volumes).",
    "executors" : [ {
      "image" : "ubuntu_simple_test_image",
      "command" : [ "echo", "This will appear in stdout, but of the 2. executor." ],
      "stdout" : "/outputs/stdout"
    }, {
      "image" : "alpine",
      "command" : [ "cat", "/outputs/stdout" ]
    } ],
    "volumes" : [ "/outputs" ],
    "logs" : [ {
      "metadata" : {
        "USER_ID" : "anonymousUser"
      },
      "start_time" : "2020-07-08T16:42:51.000Z",
      "end_time" : "2020-07-08T16:47:48.000Z",
      "system_logs" : [ "{'message': 'Back-off pulling image \"ubuntu_simple_test_image\"',\n 'reason': 'ImagePullBackOff'}\nRemoving failed jobs\nCancelling taskmaster: Got status Error\n" ]
    } ],
    "creation_time" : "2020-07-08T16:42:51.000Z"
  } ]
}```
