### PR TITLE
Fix local filesystem regression of error checking

### DIFF
--- a/src/tesk_core/filer.py
+++ b/src/tesk_core/filer.py
@@ -506,7 +506,7 @@ def main():
 
     for afile in data[args.transputtype]:
         logging.debug('Processing file: %s', afile['path'])
-        if process_file(args.transputtype, afile) != 0:
+        if process_file(args.transputtype, afile):
             logging.error('Unable to process file, aborting')
             return 1
         logging.debug('Processed file: %s', afile['path'])


### PR DESCRIPTION
#21 fixed the problem for failing FTP uploads/downloads, but introduces a problem for the shared filesystem, which skipped tests. This should fix both cases.