### PR TITLE
Support S3 credentials configuration through secrets

### DIFF
--- a/src/tesk_core/extract_endpoint.py
+++ b/src/tesk_core/extract_endpoint.py
@@ -1,0 +1,16 @@
+import configparser
+import os
+
+
+def extract_endpoint(profile="default"):
+    """ A simple utility to extract the endpoint from an S3 configuration
+    file, since it's not currently supported in the boto3 client (see
+    https://github.com/aws/aws-cli/issues/1270 ."""
+    config = configparser.ConfigParser()
+    # Path to the config generated from secret is hardcoded
+    if "AWS_CONFIG_FILE" in os.environ:
+        config.read(os.environ["AWS_CONFIG_FILE"])
+        return config[profile]["endpoint_url"]
+
+    else:
+        return None

--- a/src/tesk_core/extract_endpoint.py
+++ b/src/tesk_core/extract_endpoint.py
@@ -10,7 +10,11 @@ def extract_endpoint(profile="default"):
     # Path to the config generated from secret is hardcoded
     if "AWS_CONFIG_FILE" in os.environ:
         config.read(os.environ["AWS_CONFIG_FILE"])
-        return config[profile]["endpoint_url"]
 
-    else:
-        return None
+    # Check for a config file in the default location
+    elif os.path.exists("~/.aws/config"):
+        config.read("~/.aws/config")
+
+    # Takes care of both non-existent profile and/or field
+    return config[profile]["endpoint_url"] \
+        if config.has_option(profile, "endpoint_url") else None

--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -3,6 +3,8 @@ from tesk_core import path
 from tesk_core.path import fileEnabled
 
 
+
+
 class Filer:
     
     def getVolumes(self):           return self.spec['spec']['template']['spec']['volumes']
@@ -55,9 +57,42 @@ class Filer:
             
             self.getVolumes().append({
                 
-                  "name"                  : 'transfer-volume'
+                  "name": 'transfer-volume'
                 , 'persistentVolumeClaim' : { 'claimName' : path.TRANSFER_PVC_NAME }
             })
+
+    def add_s3_mount(self, s3_config_name='s3_config'):
+        """ Mounts the s3 configuration file into $HOME/.aws/config. The secret
+            name is given through the 'S3_SECRET_NAME' environment variable.
+        """
+
+        self.getVolumeMounts().append(
+            {
+                "name": "s3-conf",
+                "mountPath": "~/.aws",
+                # Or os.path.join(os.environ['HOME'], '/.aws') ?
+                # Also, should the subdir '.aws' exist?
+                "readOnly": True,
+            }
+        )
+        self.getVolumes().append(
+            {
+                "name": "s3-conf",
+                  "secret": {
+                      "secretName": s3_config_name,
+                      "items": [
+                          {
+                              "key": "credentials",
+                              "path": "credentials"
+                          },
+                          {
+                              "key": "config",
+                              "path": "config"
+                          }
+                      ]
+                  }
+            }
+        )
 
 
     def set_ftp(self, user, pw):

--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -3,20 +3,25 @@ from tesk_core import path
 from tesk_core.path import fileEnabled
 
 
-
-
 class Filer:
-    
-    def getVolumes(self):           return self.spec['spec']['template']['spec']['volumes']
-                                    
-    def getContainer(self, i):      return self.spec['spec']['template']['spec']['containers'][i]
-    
-    def getVolumeMounts(self):      return self.getContainer(0)['volumeMounts']
-    def getEnv(self):               return self.getContainer(0)['env']
-    def getImagePullPolicy(self):   return self.getContainer(0)['imagePullPolicy']
 
-    
-    def __init__(self, name, data, filer_name='eu.gcr.io/tes-wes/filer', filer_version='v0.5', pullPolicyAlways = False):
+    def getVolumes(self):
+        return self.spec['spec']['template']['spec']['volumes']
+
+    def getContainer(self, i):
+        return self.spec['spec']['template']['spec']['containers'][i]
+
+    def getVolumeMounts(self):
+        return self.getContainer(0)['volumeMounts']
+
+    def getEnv(self):
+        return self.getContainer(0)['env']
+
+    def getImagePullPolicy(self):
+        return self.getContainer(0)['imagePullPolicy']
+
+    def __init__(self, name, data, filer_name='eu.gcr.io/tes-wes/filer',
+                 filer_version='v0.5', pullPolicyAlways=False):
         self.name = name
         self.spec = {
             "kind": "Job",
@@ -43,57 +48,67 @@ class Filer:
         }
 
         env = self.getEnv()
-        env.append({ "name": "JSON_INPUT"           , "value": json.dumps(data)          })
-        env.append({ "name": "HOST_BASE_PATH"       , "value": path.HOST_BASE_PATH       })
-        env.append({ "name": "CONTAINER_BASE_PATH"  , "value": path.CONTAINER_BASE_PATH  })
+        env.append({"name": "JSON_INPUT", "value": json.dumps(data)})
+        env.append({"name": "HOST_BASE_PATH", "value": path.HOST_BASE_PATH})
+        env.append(
+            {"name": "CONTAINER_BASE_PATH", "value": path.CONTAINER_BASE_PATH})
 
         if fileEnabled():
-            
-            self.getVolumeMounts().append({ 
-                
-                  "name"      : 'transfer-volume'
-                , 'mountPath' : path.CONTAINER_BASE_PATH 
-            })
-            
-            self.getVolumes().append({
-                
-                  "name": 'transfer-volume'
-                , 'persistentVolumeClaim' : { 'claimName' : path.TRANSFER_PVC_NAME }
+            self.getVolumeMounts().append({
+
+                "name": 'transfer-volume'
+                , 'mountPath': path.CONTAINER_BASE_PATH
             })
 
-    def add_s3_mount(self, s3_config_name='s3_config'):
-        """ Mounts the s3 configuration file into $HOME/.aws/config. The secret
-            name is given through the 'S3_SECRET_NAME' environment variable.
+            self.getVolumes().append({
+
+                "name": 'transfer-volume'
+                ,
+                'persistentVolumeClaim': {'claimName': path.TRANSFER_PVC_NAME}
+            })
+
+        self.add_s3_mount()
+
+    def add_s3_mount(self):
+        """ Mounts the s3 configuration file. The secret name is hardcoded and
+            set to 'aws-secret'.
         """
+
+        env = self.getEnv()
+        env.append({"name": "AWS_CONFIG_FILE", "value": "/aws/config"})
+        env.append(
+            {
+                "name": "AWS_SHARED_CREDENTIALS_FILE",
+                "value": "/aws/credentials"
+            }
+        )
 
         self.getVolumeMounts().append(
             {
                 "name": "s3-conf",
-                "mountPath": "~/.aws",
-                # Or os.path.join(os.environ['HOME'], '/.aws') ?
-                # Also, should the subdir '.aws' exist?
+                "mountPath": "/aws",
                 "readOnly": True,
             }
         )
         self.getVolumes().append(
             {
                 "name": "s3-conf",
-                  "secret": {
-                      "secretName": s3_config_name,
-                      "items": [
-                          {
-                              "key": "credentials",
-                              "path": "credentials"
-                          },
-                          {
-                              "key": "config",
-                              "path": "config"
-                          }
-                      ]
-                  }
+                "secret": {
+                    "secretName": "aws-secret",
+                    "items": [
+                        {
+                            "key": "credentials",
+                            "path": "credentials"
+                        },
+                        {
+                            "key": "config",
+                            "path": "config"
+                        }
+                    ],
+                    "optional": True,
+                }
             }
         )
-
 
     def set_ftp(self, user, pw):
         env = self.getEnv()
@@ -111,15 +126,17 @@ class Filer:
 
     def add_volume_mount(self, pvc):
         self.getVolumeMounts().extend(pvc.volume_mounts)
-        self.getVolumes().append({ "name"                  : "task-volume",
-                                   "persistentVolumeClaim" : {"claimName": pvc.name}})
+        self.getVolumes().append({"name": "task-volume",
+                                  "persistentVolumeClaim": {
+                                      "claimName": pvc.name}})
 
     def get_spec(self, mode, debug=False):
         self.spec['spec']['template']['spec']['containers'][0]['args'] = [
             mode, "$(JSON_INPUT)"]
 
         if debug:
-            self.spec['spec']['template']['spec']['containers'][0]['args'].append(
+            self.spec['spec']['template']['spec']['containers'][0][
+                'args'].append(
                 '-d')
 
         self.spec['spec']['template']['metadata']['name'] = self.name

--- a/tests/FilerClassTest.py
+++ b/tests/FilerClassTest.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 import unittest
+import os
 from tesk_core.filer_class import Filer
 from tesk_core import path
 from tesk_core.Util import pprint
@@ -16,23 +17,31 @@ except:
 @patch('tesk_core.path.HOST_BASE_PATH'          , '/home/tfga/workspace/cwl-tes')
 @patch('tesk_core.path.CONTAINER_BASE_PATH'     , '/transfer')
 @patch('tesk_core.path.TRANSFER_PVC_NAME'       , 'transfer-pvc')
+@patch.dict(os.environ,
+            {
+                "AWS_SHARED_CREDENTIALS_FILE": "/aws/credentials",
+                "AWS_CONFIG_FILE": "/aws/config",
+            })
 class FilerClassTest_env(unittest.TestCase):
 
     def test_env_vars(self):
-        
+
         f = Filer('name', {'a': 1})
         f.set_backoffLimit(10)
 
         pprint(f.spec)
-        
+
         self.assertEquals(f.getEnv(), [
-            
+
             { 'name': 'JSON_INPUT'           , 'value': '{"a": 1}'                      }
            ,{ 'name': 'HOST_BASE_PATH'       , 'value': '/home/tfga/workspace/cwl-tes'  }
            ,{ 'name': 'CONTAINER_BASE_PATH'  , 'value': '/transfer'                     }
+            ,{"name": "AWS_CONFIG_FILE", "value": "/aws/config"}
+            ,{"name": "AWS_SHARED_CREDENTIALS_FILE", "value": "/aws/credentials"},
         ])
         self.assertEquals(f.spec['spec']['backoffLimit'], 10)
-    
+
+
     def test_mounts(self):
         '''
         kind: Pod
@@ -53,56 +62,94 @@ class FilerClassTest_env(unittest.TestCase):
               # persistentVolumeClaim:
               #  claimName: task-pv-claim
         '''
-        
+
         f = Filer('name', {'a': 1})
-        
+
         pprint(f.spec)
-        
+
         pprint(f.getVolumeMounts())
-        
+
         self.assertEquals(f.getVolumeMounts(), [
-            
+
             { "name"        : 'transfer-volume'
-            , 'mountPath'   : path.CONTAINER_BASE_PATH 
-            }
+            , 'mountPath'   : path.CONTAINER_BASE_PATH,
+            },
+            {'mountPath': '/aws', 'name': 's3-conf', 'readOnly': True}
         ])
-        
+
         self.assertEquals(f.getVolumes(), [
-            
+
             { "name"                  : 'transfer-volume'
             , 'persistentVolumeClaim' : { 'claimName' : 'transfer-pvc' }
+            },
+            {
+                "name": "s3-conf",
+                "secret": {
+                    "secretName": "aws-secret",
+                    "items": [
+                        {
+                            "key": "credentials",
+                            "path": "credentials"
+                        },
+                        {
+                            "key": "config",
+                            "path": "config"
+                        }
+                    ],
+                    "optional": True,
+                }
             }
         ])
 
-        
+
 class FilerClassTest_no_env(unittest.TestCase):
 
     def test_mounts_file_disabled(self):
-        
-        f = Filer('name', {'a': 1})
-        
-        pprint(f.spec)
-        
-        pprint(f.getVolumeMounts())
-        
-        self.assertEquals(f.getVolumeMounts()   , [])
-        self.assertEquals(f.getVolumes()        , [])
 
-        
+        f = Filer('name', {'a': 1})
+
+        pprint(f.spec)
+
+        pprint(f.getVolumeMounts())
+
+        self.assertEquals(f.getVolumeMounts()   , [
+            {'mountPath': '/aws', 'name': 's3-conf', 'readOnly': True}
+        ])
+        self.assertEquals(f.getVolumes()        , [
+            {
+                "name": "s3-conf",
+                "secret": {
+                    "secretName": "aws-secret",
+                    "items": [
+                        {
+                            "key": "credentials",
+                            "path": "credentials"
+                        },
+                        {
+                            "key": "config",
+                            "path": "config"
+                        }
+                    ],
+                    "optional": True,
+                }
+            }
+        ])
+
+
     def test_image_pull_policy(self):
-        
+
         f = Filer('name', {'a': 1})
         self.assertEquals(f.getImagePullPolicy()   , 'IfNotPresent')
 
         f = Filer('name', {'a': 1}, pullPolicyAlways = True)
         self.assertEquals(f.getImagePullPolicy()   , 'Always')
-        
-
-        
 
 
 
-    
+
+
+
+
 if __name__ == "__main__":
     #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/tests/resources/test_config
+++ b/tests/resources/test_config
@@ -1,0 +1,5 @@
+[default]
+endpoint_url=http://foo.bar
+
+[other_profile]
+endpoint_url=http://other.endpoint

--- a/tests/test_extract_endpoint.py
+++ b/tests/test_extract_endpoint.py
@@ -1,0 +1,35 @@
+import unittest
+import os
+from unittest.mock import patch
+
+from tesk_core.extract_endpoint import extract_endpoint
+
+
+@patch.dict(os.environ, {"AWS_CONFIG_FILE": "resources/test_config"})
+class ExtractEndpointTest(unittest.TestCase):
+
+    def test_default_profile(self):
+        self.assertEqual(extract_endpoint(), "http://foo.bar")
+
+    def test_other_profile(self):
+        self.assertEqual(
+            extract_endpoint("other_profile"),
+            "http://other.endpoint"
+        )
+
+    def test_non_existent_profile(self):
+        """ In case a profile does not exist, 'None' should be returned. """
+        self.assertEqual(extract_endpoint("random_profile"), None)
+
+    def test_unset_env_var(self):
+        """ In case the 'AWS_CONFIG_FILE' env var is not set and there's no
+            config file in the default location, the result should be 'None'.
+        """
+        exists = unittest.mock
+        exists.patch("os.path.exists", return_value = False)
+        os.environ.pop("AWS_CONFIG_FILE")
+        self.assertEqual(extract_endpoint(), None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_extract_endpoint.py
+++ b/tests/test_extract_endpoint.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from tesk_core.extract_endpoint import extract_endpoint
 
 
-@patch.dict(os.environ, {"AWS_CONFIG_FILE": "resources/test_config"})
+@patch.dict(os.environ, {"AWS_CONFIG_FILE": "tests/resources/test_config"})
 class ExtractEndpointTest(unittest.TestCase):
 
     def test_default_profile(self):


### PR DESCRIPTION
Credentials for using an S3 storage can now be set up through using a secret. 
The first thing that's needed is the existence of a `credentials` and a `config` file, defined according to [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). The goal is to recreate these files in a Kubernetes Pod volume via the use of a secret. 
### Creating a secret
Given that both the `credentials` and the `config` files are in the working directory, we need to run the following:
```bash
kubectl create secret generic aws-secret --from-file=config=./config --from-file=credentials=./credentials
```
The name of the secret is `aws-secret` and is hardcoded at the moment.

Note: `extract_endpoint.py` might not really belong in this PR and can therefore be removed if needed.