### PR TITLE
Move HOME for .netrc - fix #31

### DIFF
--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -83,7 +83,7 @@ class Filer:
 
     def add_netrc_mount(self, netrc_name='netrc'):
         '''
-            Sets $HOME to a particular location (to prevent its change as a result of runAsUser), currently hardcoded to `/opt/home`
+            Sets $HOME to an arbitrary location (to prevent its change as a result of runAsUser), currently hardcoded to `/opt/home`
             Mounts the secret netrc into that location: $HOME/.netrc.
         '''
 

--- a/src/tesk_core/filer_class.py
+++ b/src/tesk_core/filer_class.py
@@ -83,12 +83,12 @@ class Filer:
 
     def add_netrc_mount(self, netrc_name='netrc'):
         '''
-            Mounts the secret netrc into $HOME/.netrc. Neither the secret name nor the folder
-                can be changed.
+            Sets $HOME to a particular location (to prevent its change as a result of runAsUser), currently hardcoded to `/opt/home`
+            Mounts the secret netrc into that location: $HOME/.netrc.
         '''
 
         self.getVolumeMounts().append({"name"      : 'netrc',
-                                       "mountPath" : '/tmp/user/.netrc',
+                                       "mountPath" : '/opt/home/.netrc',
                                        "subPath" : ".netrc"
                                       })
         self.getVolumes().append({"name"   : "netrc",
@@ -103,11 +103,9 @@ class Filer:
                                       ]
                                   }
                                  })
-        self.getContainer(0)['lifecycle'] = { "postStart" : {
-                                                    "exec": {
-                                                        "command": ["/bin/sh", "-c", "cp /tmp/user/.netrc $HOME"]
-                                                    }
-                                            }}
+        self.getEnv().append({"name": "HOME",
+                              "value": "/opt/home"
+                            })
 
 
     def get_spec(self, mode, debug=False):


### PR DESCRIPTION
Unfortunately, `runAsUser` moves HOME and makes it read-only. Hence, an idea to move HOME to some arbitrary directory, where the .netrc secret will be mount.

I have built an image - the new version for taskmaster `nerc-sethome1`. It works for me. @lvarin - can you have a look, if that option works for you as well?
