### PR TITLE
Bug Fix: When polling pod.status.start_time. 

### DIFF
--- a/src/tesk_core/job.py
+++ b/src/tesk_core/job.py
@@ -52,7 +52,7 @@ class Job:
                                                     , label_selector='job-name={}'.format(self.name))).items
                 is_all_pods_runnning = True
                 for pod in pods:
-                    if pod.status.phase == "Pending":
+                    if pod.status.phase == "Pending" and pod.status.start_time:
                         is_all_pods_runnning = False
                         delta = (datetime.now(timezone.utc) - pod.status.start_time).total_seconds()
                         if delta > self.timeout and \


### PR DESCRIPTION
Initially I assumed that `pod.status.start_time` value will be present when polling the status of the pod. However, there were cases when its value will be `None` (to reproduce the error, delete the storage class in k8). To prevent this bug, additional check was neccesary. Now condition is added and the generic error message will be logged.