### PR TITLE
Improving taskmaster

### DIFF
--- a/src/tesk_core/job.py
+++ b/src/tesk_core/job.py
@@ -26,8 +26,11 @@ class Job:
         try:
             self.bv1.create_namespaced_job(self.namespace, self.body)
         except ApiException as ex:
-            logging.debug(ex)
-            self.bv1.read_namespaced_job(self.name, self.namespace)
+            if ex.status == 409:
+                self.bv1.read_namespaced_job(self.name, self.namespace)
+            else:
+                logging.error(ex.body)
+                raise ApiException(ex.status, ex.reason)
         is_all_pods_running = False
         status, is_all_pods_running = self.get_status(is_all_pods_running)
         while status == 'Running':

--- a/src/tesk_core/job.py
+++ b/src/tesk_core/job.py
@@ -27,9 +27,10 @@ class Job:
             self.bv1.create_namespaced_job(self.namespace, self.body)
         except ApiException as ex:
             if ex.status == 409:
+                logging.debug(f"Reading existing job: {self.name} ")
                 self.bv1.read_namespaced_job(self.name, self.namespace)
             else:
-                logging.error(ex.body)
+                logging.debug(ex.body)
                 raise ApiException(ex.status, ex.reason)
         is_all_pods_running = False
         status, is_all_pods_running = self.get_status(is_all_pods_running)

--- a/src/tesk_core/pvc.py
+++ b/src/tesk_core/pvc.py
@@ -1,4 +1,5 @@
 from kubernetes import client, config
+from kubernetes.client.rest import ApiException
 from tesk_core.Util import pprint
 import logging
 
@@ -33,8 +34,12 @@ class PVC():
         
         logging.debug('Creating PVC...')
         logging.debug(pprint(self.spec))
-        
-        return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
+        try:
+            return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
+        except ApiException as ex:
+            logging.debug(ex)
+            return self.cv1.read_namespaced_persistent_volume_claim(self.name, self.namespace)
+
 
     def delete(self):
         cv1 = client.CoreV1Api()

--- a/src/tesk_core/pvc.py
+++ b/src/tesk_core/pvc.py
@@ -37,8 +37,11 @@ class PVC():
         try:
             return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
         except ApiException as ex:
-            logging.debug(ex)
-            return self.cv1.read_namespaced_persistent_volume_claim(self.name, self.namespace)
+            if ex.status == 409:
+                return self.cv1.read_namespaced_persistent_volume_claim(self.name, self.namespace)
+            else:
+                logging.error(ex.body)
+                raise ApiException(ex.status, ex.reason)
 
 
     def delete(self):

--- a/src/tesk_core/pvc.py
+++ b/src/tesk_core/pvc.py
@@ -38,9 +38,10 @@ class PVC():
             return self.cv1.create_namespaced_persistent_volume_claim(self.namespace, self.spec)
         except ApiException as ex:
             if ex.status == 409:
+                logging.debug(f"Reading existing PVC: {self.name}")
                 return self.cv1.read_namespaced_persistent_volume_claim(self.name, self.namespace)
             else:
-                logging.error(ex.body)
+                logging.debug(ex.body)
                 raise ApiException(ex.status, ex.reason)
 
 

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -296,13 +296,9 @@ def clean_on_interrupt():
     for job in created_jobs:
         job.delete()
 
-    if created_pvc:
-        created_pvc.delete()
 
 
 def exit_cancelled(reason='Unknown reason'):
-    if created_pvc:
-        created_pvc.delete()
     logger.error('Cancelling taskmaster: ' + reason)
     sys.exit(0)
 


### PR DESCRIPTION
Improving the functionality of taskmaster so that when a taskmaster process fails (because of K8s problems, transient error, such as K8s API response error), it should resume the task execution.