### PR TITLE
Make a bit better the scripts

### DIFF
--- a/scripts/dockerBuild
+++ b/scripts/dockerBuild
@@ -1,10 +1,31 @@
-
-
-# 
+#!/bin/bash
+#
 # Usage:
-# 
+#
 #     buildDockerImage filer          or
 #     buildDockerImage taskmaster
-# 
+#
 
-docker build -t "eu.gcr.io/tes-wes/$1:testing" -f "containers/$1.Dockerfile" .
+IMAGE=$1
+
+if [ -z "$IMAGE" ];
+then
+  echo "Use: $0 <filer/taskmaster> [tag]"
+  exit 12
+fi
+
+TAG=$2
+
+if [ -z "$TAG" ];
+then
+  TAG=testing
+fi
+
+if command -V buildah;
+then
+  buildah bud -t "docker.io/elixircloud/tesk-core-$IMAGE:$TAG" \
+    --format=docker --no-cache \
+    -f "containers/$IMAGE.Dockerfile"
+else
+  docker build -t "docker.io/elixircloud/tesk-core-$1:$TAG" -f "containers/$1.Dockerfile" .
+fi

--- a/scripts/dockerRun
+++ b/scripts/dockerRun
@@ -1,13 +1,12 @@
-
-# 
+#!/bin/bash
+#
 # Usage:
-# 
+#
 #     buildRun filer          or
 #     buildRun taskmaster
-# 
+#
 
 imageName="$1"
 shift
 
-docker run "eu.gcr.io/tes-wes/$imageName:testing" "$@"
-
+docker run "docker.io/elixircloud/tesk-core-$imageName:testing" "$@"


### PR DESCRIPTION
Few minor improvements of build and run script:

- Old scripts were building images with the old google server `eu.gcr.io/tes-wes/$1:testing`.
- Using rootless buiildah, that allows to build with older docker format (Rahti issue).
- Added possibility to change the tag.
- Fixed suggested issues by `shellcheck`, like the no shebang problem
