### PR TITLE
fix: handle null values for TES volumes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ TEST_DEPS = [ 'pytest',
             'pyfakefs',
             'pytest-mock'
             , 'fs',
-            'moto',
+            'moto<5',
             'pytest-localftpserver'
             ]
 

--- a/src/tesk_core/filer.py
+++ b/src/tesk_core/filer.py
@@ -240,6 +240,7 @@ class FTPTransput(Transput):
 
 def ftp_login(ftp_connection, netloc, netrc_file):
     user = None
+    password=None
     if netrc_file is not None:
         creds = netrc_file.authenticators(netloc)
         if creds:

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -29,6 +29,10 @@ def run_executor(executor, namespace, pvc=None):
         mounts = spec['containers'][0].setdefault('volumeMounts', [])
         mounts.extend(pvc.volume_mounts)
         volumes = spec.setdefault('volumes', [])
+        if volumes is None:
+            spec['volumes'] = []
+            # volumes is a refence to spec['volumes']
+            # This makes sure the next line does not fail if volumes was originaly "null"
         volumes.extend([{'name': task_volume_basename, 'persistentVolumeClaim': {
             'readonly': False, 'claimName': pvc.name}}])
     logger.debug('Created job: ' + jobname)

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -28,12 +28,12 @@ def run_executor(executor, namespace, pvc=None):
     if pvc is not None:
         mounts = spec['containers'][0].setdefault('volumeMounts', [])
         mounts.extend(pvc.volume_mounts)
-        volumes = spec.setdefault('volumes', [])
-        if volumes is None:
+        spec.setdefault('volumes', [])
+        if spec['volumes'] is None:
             spec['volumes'] = []
             # volumes is a refence to spec['volumes']
             # This makes sure the next line does not fail if volumes was originaly "null"
-        volumes.extend([{'name': task_volume_basename, 'persistentVolumeClaim': {
+        spec['volumes'].extend([{'name': task_volume_basename, 'persistentVolumeClaim': {
             'readonly': False, 'claimName': pvc.name}}])
     logger.debug('Created job: ' + jobname)
     job = Job(executor, jobname, namespace)


### PR DESCRIPTION
If spec.template.spec.volumes is null, use [] instead of None.

This is just to make taskmaster more robust

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the handling of null values in spec.template.spec.volumes by defaulting to an empty list to enhance robustness.

Bug Fixes:
- Ensure that if spec.template.spec.volumes is null, it defaults to an empty list instead of None to prevent potential errors.

<!-- Generated by sourcery-ai[bot]: end summary -->