### PR TITLE
Fix: restartPolicy and limits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with codecs.open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
 
 INSTALL_DEPS = ['kubernetes==9.0.0',
                 'requests>=2.20.0',
-                'urllib3==1.26.18',
+                'urllib3==1.26.19',
                 'boto3==1.16.18',
                 ]
 TEST_DEPS = [ 'pytest',

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -25,6 +25,15 @@ def run_executor(executor, namespace, pvc=None):
     if os.environ.get('EXECUTOR_BACKOFF_LIMIT') is not None:
         executor['spec'].update({'backoffLimit': int(os.environ['EXECUTOR_BACKOFF_LIMIT'])})
 
+    if 'restartPolicy'  not in spec.keys() and \
+       'restart_policy' in spec.keys():
+        spec['restartPolicy'] = spec['restart_policy']
+
+    for container in spec['containers']:
+        if container['resources']['limits'] is None and \
+           container['resources']['requests'] is not None:
+            container['resources']['limits'] = container['resources']['requests']
+
     if pvc is not None:
         mounts = spec['containers'][0].setdefault('volumeMounts', [])
         mounts.extend(pvc.volume_mounts)

--- a/src/tesk_core/taskmaster.py
+++ b/src/tesk_core/taskmaster.py
@@ -30,8 +30,11 @@ def run_executor(executor, namespace, pvc=None):
         spec['restartPolicy'] = spec['restart_policy']
 
     for container in spec['containers']:
+        if 'limits' not in container['resources'].keys():
+            container['resources']['limits'] = None
         if container['resources']['limits'] is None and \
-           container['resources']['requests'] is not None:
+          ('requests' in container['resources'].keys() and \
+           container['resources']['requests'] is not None):
             container['resources']['limits'] = container['resources']['requests']
 
     if pvc is not None:


### PR DESCRIPTION
- If restart_policy but restartPolicy does not, uses the former to populate the later
- If limits is empty, uses requests so limits == requests

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix issues with task specification by ensuring 'restartPolicy' is set from 'restart_policy' when missing, and aligning 'limits' with 'requests' in container resources when 'limits' is not specified.

Bug Fixes:
- Ensure 'restartPolicy' is populated from 'restart_policy' if the former is missing.
- Set 'limits' to equal 'requests' in container resources if 'limits' is empty and 'requests' is not.

<!-- Generated by sourcery-ai[bot]: end summary -->