### PR TITLE
Python3.8 EOL for urllib3>2.0

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ HERE = path.abspath(path.dirname(__file__))
 with codecs.open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     LONG_DESC = f.read()
 
-INSTALL_DEPS = ['kubernetes==9.0.0',
+INSTALL_DEPS = ['kubernetes>=9.0.0',
                 'requests>=2.20.0',
                 'urllib3==2.6.3',
                 'boto3==1.42.30',

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,24 @@
 [tox]
 envlist =
-  py{38,39,310,311}-unit,
-  py{38,39,310,311}-lint
+  py{39,310,311}-unit,
+  py{39,310,311}-lint
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
 
 [testenv]
 passenv = CI, TRAVIS, TRAVIS_*
 deps =
-  py{38,39,310,311}: .[test]
-  py{38,39,310,311}-unit: pytest-cov
+  py{39,310,311}: .[test]
+  py{39,310,311}-unit: pytest-cov
     codecov
-  py{38,39,310,311}-lint: pylint
+  py{39,310,311}-lint: pylint
 commands =
-  py{38,39,310,311}-unit: pytest -v --cov-report xml --cov tesk_core {posargs} tests
-  py{38,39,310,311}-unit: codecov
-  py{38,39,310,311}-lint: python -m pylint --exit-zero -d missing-docstring,line-too-long,C tesk_core
-  py{38,39,310,311}-lint: python -m pylint -E tesk_core
+  py{39,310,311}-unit: pytest -v --cov-report xml --cov tesk_core {posargs} tests
+  py{39,310,311}-unit: codecov
+  py{39,310,311}-lint: python -m pylint --exit-zero -d missing-docstring,line-too-long,C tesk_core
+  py{39,310,311}-lint: python -m pylint -E tesk_core


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update tox test and lint environments to only run for Python 3.9, 3.10, and 3.11.