### PR TITLE
Fix GitHub Actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,14 @@ with codecs.open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
 
 INSTALL_DEPS = ['kubernetes==9.0.0',
                 'requests>=2.20.0',
-                'urllib3==2.6.3',
-                'boto3==1.42.30',
+
+                # urllib3 constraint
+                'urllib3>=1.26,<2.0 ; python_version < "3.10"',
+                'urllib3>=2.0,<3.0 ; python_version >= "3.10"',
+
+                # boto3 constraint
+                'boto3<=1.28 ; python_version == "3.8"',
+                'boto3>=1.28 ; python_version >= "3.9"',
                 ]
 TEST_DEPS = [ 'pytest',
             'pyfakefs',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
## Summary by Sourcery

Adjust Python dependency constraints and CI Python version support.

Enhancements:
- Relax and parameterize urllib3 and boto3 version constraints based on supported Python versions.

CI:
- Drop Python 3.7 from the GitHub Actions/tox test matrix.